### PR TITLE
auth_token to remotes of remotes

### DIFF
--- a/R/install-gitlab.R
+++ b/R/install-gitlab.R
@@ -115,6 +115,10 @@ remote_package_name.gitlab_remote <- function(remote, ...) {
 
 #' @export
 remote_sha.gitlab_remote <- function(remote, ...) {
+   if (is.null(remote$auth_token)) {
+    auth_token <- list(...)
+    remote$auth_token <- auth_token$auth_token
+  }
   gitlab_commit(username = remote$username, repo = remote$repo,
     host = remote$host, ref = remote$ref, pat = remote$auth_token)
 }


### PR DESCRIPTION
When a package which is listed as Remotes in description has a package listed as Remotes, the auth_token didn't transfer correctly. This regrabs it from the ...